### PR TITLE
change action hook to ensure all plugins could load all their functio…

### DIFF
--- a/bea-missed-schedule.php
+++ b/bea-missed-schedule.php
@@ -14,7 +14,7 @@ class BEA_Missed_Schedule {
 	const option_name = 'bea_missed_schedule';
 
 	public function __construct() {
-		add_action( 'init', array( __CLASS__, 'init' ), 0 );
+		add_action( 'wp_loaded', array( __CLASS__, 'init' ), 0 );
 	}
 
 	public static function deactivation() {


### PR DESCRIPTION
…nnalities

If you want to do some checks before allowing a post to be published, say for example look for a P2P connection etc, action hook `init` is a bit early.
If we run our plugin on `wp_loaded` we'll be sure all other plugins did finish load all their functionnalities.